### PR TITLE
Add dokku-link to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Requirements
 ------------
 * Docker version `0.7.2` or higher
 * Dokku version `0.2.1` or higher
+* Install [dokku-link](https://github.com/rlaneve/dokku-link) plugin
 
 Instalation
 -----------


### PR DESCRIPTION
I think that was not explicit enough. I found out I needed to install it after reading this error message on my terminal:

```
# dokku rabbitmq:list
Link plugin not found... Did you install it from https://github.com/rlaneve/dokku-link?
```
