### PR TITLE
Add missing plugin.toml

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,5 @@
+[plugin]
+description = "RabbitMQ plugin for Dokku"
+version = "0.0.0"
+[plugin.config]
+


### PR DESCRIPTION
As of version 0.4.0+ of Dokku plugins now require a plugin.toml file containing meta data.

http://dokku.viewdocs.io/dokku~v0.4.14/development/plugin-creation/
